### PR TITLE
TL-369: use metric filter capture group as key

### DIFF
--- a/nuxeo-statistics-web-ui/src/elements/nuxeo-statistics-data.js
+++ b/nuxeo-statistics-web-ui/src/elements/nuxeo-statistics-data.js
@@ -65,7 +65,7 @@ class StatisticsData extends Nuxeo.Element {
     const params = {};
     let { filter } = this;
     if (this.metric) {
-      filter = `nuxeo.statistics.${this.metric}.*`;
+      filter = `nuxeo.statistics.${this.metric}`;
     }
     if (filter !== '*') {
       params.filter = filter;
@@ -78,7 +78,13 @@ class StatisticsData extends Nuxeo.Element {
             if (k === 'ts') {
               return ['ts', moment(v * 1000).format(this.dateFormat)];
             }
-            return [this.metric ? k.replace(`nuxeo.statistics.${this.metric}.`, '') : k, v];
+            let key = k;
+            if (this.metric) {
+              // check is there's a capture group in the metric regex
+              // if so, use it as key
+              key = k.match(this.metric)[1] || k;
+            }
+            return [key.replace('nuxeo.statistics', ''), v];
           }),
         ),
       );

--- a/nuxeo-statistics-web-ui/src/elements/nuxeo-statistics-page.js
+++ b/nuxeo-statistics-web-ui/src/elements/nuxeo-statistics-page.js
@@ -71,7 +71,10 @@ class StatisticsPage extends mixinBehaviors([I18nBehavior], PolymerElement) {
         }
       </style>
 
-      <nuxeo-statistics-data metric="repository.documents" data="{{documentsStats}}"></nuxeo-statistics-data>
+      <nuxeo-statistics-data
+        metric="repository.documents.(.+).default"
+        data="{{documentsStats}}"
+      ></nuxeo-statistics-data>
 
       <!-- Document count per type -->
       <nuxeo-card heading="[[i18n('statistics.documentTypes.heading')]]">
@@ -88,7 +91,7 @@ class StatisticsPage extends mixinBehaviors([I18nBehavior], PolymerElement) {
         <chart-line
           values="[[documentsTS.values]]"
           labels="[[documentsTS.labels]]"
-          series="[[_stripRepo(documentsTS.series)]]"
+          series="[[documentsTS.series]]"
         ></chart-line>
       </nuxeo-card>
     `;
@@ -110,7 +113,7 @@ class StatisticsPage extends mixinBehaviors([I18nBehavior], PolymerElement) {
   }
 
   _labels(obj) {
-    return this._stripRepo(Object.keys(obj));
+    return Object.keys(obj);
   }
 
   _values(obj) {
@@ -119,11 +122,9 @@ class StatisticsPage extends mixinBehaviors([I18nBehavior], PolymerElement) {
 
   _documentsStatsChanged(data) {
     this.documentsTS = _buildTS(data);
-    this.documents = data[data.length - 1];
-  }
-
-  _stripRepo(ks) {
-    return ks.map((k) => k.split('.')[0]);
+    const documents = { ...data[data.length - 1] };
+    delete documents.ts;
+    this.documents = documents;
   }
 }
 


### PR DESCRIPTION
Idea is to use the regex capture group to define the key for the data returned, ie with `<nuxeo-statistics-data metric="repository.documents.(.+).default"/>` we get the doc counts for the default repo with the doctype as key. 